### PR TITLE
Ensure same temp_filepath across MPI processes

### DIFF
--- a/h5flow/data/h5flow_data_manager.py
+++ b/h5flow/data/h5flow_data_manager.py
@@ -48,11 +48,11 @@ class H5FlowDataManager(object):
         if drop_list:
             self.drop_list = drop_list
             uid = uuid.uuid4()
-            if self.mpi_flag:
-                uid = self.comm.bcast(uid, root=0)
 
             self._temp_filepath = os.path.join(os.path.dirname(self.filepath),
                                                time.strftime(self._temp_filename_fmt).format(uid=uid))
+            if self.mpi_flag:
+                self._temp_filepath = self.comm.bcast(self._temp_filepath, root=0)
             logging.info(f'writing temporary data to {self._temp_filepath}')
         else:
             self.drop_list = list()


### PR DESCRIPTION
Previously, when only the uuid was broadcast, it was possible for different processes to get different timestamps (e.g. off by one second), leading to different temp_filepaths. This had caused a crash.